### PR TITLE
Update rungrafana

### DIFF
--- a/root/usr/bin/rungrafana
+++ b/root/usr/bin/rungrafana
@@ -2,7 +2,7 @@
 
 export GF_PATHS_DATA=/var/lib/grafana
 export GF_PATHS_LOGS=/var/log/grafana
-export GF_PATHS_PLUGINS=/var/lib/grafana-plugins
+export GF_PATHS_PLUGINS=/var/lib/grafana/plugins
 
 # Determine UID and GID under which the container is running
 export USER_ID=$(id -u)


### PR DESCRIPTION
Folder incorret
Maybe will be better export ENV variables from OpenShift?!
t=2017-11-11T19:05:06+0000 lvl=warn msg="Plugin dir does not exist" logger=plugins dir=/var/lib/grafana-plugins
t=2017-11-11T19:05:06+0000 lvl=warn msg="Failed to create plugin dir" logger=plugins dir=/var/lib/grafana-plugins error="mkdir /var/lib/grafana-plugins: permission denied"